### PR TITLE
Fix memory leak issue by explicitly clean up contentRef upon unmount

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -31,14 +31,19 @@ const AutoScrolling = ({
   const [isAutoScrolling, setIsAutoScrolling] = React.useState(false);
   const [dividerWidth, setDividerWidth] = React.useState(endPaddingWidth);
   const offsetX = React.useRef(new Animated.Value(0));
-  let contentRef: any;
+  const contentRef = React.useRef(0);
+
+  React.useEffect(() => {
+    // Clean up to avoid calling measureContainerView after unmount.
+    return () => (contentRef.current = 0);
+  });
 
   function measureContainerView(event: LayoutChangeEvent) {
     const newContainerWidth = event.nativeEvent.layout.width;
     if (containerWidth.current === newContainerWidth) return;
     containerWidth.current = newContainerWidth;
-    if (!contentRef) return;
-    contentRef.measure((fx: number, fy: number, width: number) => {
+    if (!contentRef.current) return;
+    contentRef.current.measure((fx: number, fy: number, width: number) => {
       checkContent(width, fx);
     });
   }
@@ -87,7 +92,7 @@ const AutoScrolling = ({
   const childrenWithProps = React.cloneElement(children, {
     ...childrenProps,
     onLayout: measureContentView,
-    ref: (ref: any) => (contentRef = ref),
+    ref: (ref: any) => (contentRef.current = ref),
   });
 
   return (


### PR DESCRIPTION
I encounter this warning while using the auto scrolling component ("react": "^17.0.1", "react-native": "^0.64.0").

```
Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in a useEffect cleanup function.
```
It typically means some async function is called after `AutoScrolling` is unmounted. The culprit points to `setIsAutoScrolling` inside `checkContent`. This is understandable as `checkContent` is called in `measureContainerView`, which is a callback that can be scheduled to run after component unmount.

The fix is to clean up `contentRef`, such that `checkContent` won't be called in `measureContainerView` upon component unmount.