### PR TITLE
fix bug: when isLTR = true, render incorrectly

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -177,19 +177,11 @@ const AutoScrolling = ({
         scrollEnabled={false}
         showsHorizontalScrollIndicator={false}
       >
-        {isLTR ? (
-          <Animated.View style={animatedViewStyle}>
-            {isAutoScrolling && children}
-            {isAutoScrolling && <View style={viewStyle} />}
-            {childrenWithProps}
-          </Animated.View>
-        ) : (
-          <Animated.View style={animatedViewStyle}>
-            {childrenWithProps}
-            {isAutoScrolling && <View style={viewStyle} />}
-            {isAutoScrolling && children}
-          </Animated.View>
-        )}
+        <Animated.View style={animatedViewStyle}>
+          {childrenWithProps}
+          {isAutoScrolling && <View style={viewStyle} />}
+          {isAutoScrolling && children}
+        </Animated.View>
       </ScrollView>
     </View>
   );


### PR DESCRIPTION
1. first row is isLTR = false
2. second row is isLTR = true

actual behavior
![actual](https://user-images.githubusercontent.com/38369729/144958745-68fc4095-d065-4d61-aea3-9e2c446ea38d.gif)

expected behavior (fixed)
![expected](https://user-images.githubusercontent.com/38369729/144958750-3a985455-ee3c-4293-9484-b3dbc9f6562c.gif)
