### PR TITLE
fix: remove useEffect causing the animation to stop

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -34,12 +34,6 @@ const AutoScrolling = ({
   const offsetX = React.useRef(new Animated.Value(0));
   const contentRef = React.useRef<any>(null);
 
-  React.useEffect(() => {
-    return () => {
-      contentRef.current = null;
-    };
-  });
-
   const measureContainerView = React.useCallback(
     ({
       nativeEvent: {


### PR DESCRIPTION
This pull request relates to the following issue: https://github.com/homielab/react-native-auto-scroll/issues/23#issuecomment-1709999463

Resetting `contentRef.current` to `null` leads to unexpected behaviors and the scrolling animation usually stops.
It seems that React is already resetting refs when the component is unmounted. 

I deleted the code snippet causing this problem.